### PR TITLE
Add option to parse end tag if no whitespace present

### DIFF
--- a/rispy/parser.py
+++ b/rispy/parser.py
@@ -165,7 +165,7 @@ class Wok(Base):
 
 class Ris(Base):
     START_TAG = "TY"
-    PATTERN = "^[A-Z][A-Z0-9]  - |^ER  -[\s|]$"
+    PATTERN = r"^[A-Z][A-Z0-9]  - |^ER  -[\s|]$"
     default_mapping = TAG_KEY_MAPPING
 
     counter_re = re.compile("^[0-9]+.")

--- a/rispy/parser.py
+++ b/rispy/parser.py
@@ -165,7 +165,7 @@ class Wok(Base):
 
 class Ris(Base):
     START_TAG = "TY"
-    PATTERN = r"^[A-Z][A-Z0-9]  - |^ER  -[\s|]$"
+    PATTERN = r"^[A-Z][A-Z0-9]  - |^ER  -\s*$"
     default_mapping = TAG_KEY_MAPPING
 
     counter_re = re.compile("^[0-9]+.")

--- a/rispy/parser.py
+++ b/rispy/parser.py
@@ -165,7 +165,7 @@ class Wok(Base):
 
 class Ris(Base):
     START_TAG = "TY"
-    PATTERN = "^[A-Z][A-Z0-9]  - "
+    PATTERN = "^[A-Z][A-Z0-9]  - |^ER  -[\s|]$"
     default_mapping = TAG_KEY_MAPPING
 
     counter_re = re.compile("^[0-9]+.")

--- a/tests/data/example_full_without_whitespace.ris
+++ b/tests/data/example_full_without_whitespace.ris
@@ -1,0 +1,49 @@
+1.
+TY  - JOUR
+ID  - 12345
+T1  - Title of reference
+A1  - Marx, Karl
+A1  - Lindgren, Astrid
+A2  - Glattauer, Daniel
+Y1  - 2014//
+N2  - BACKGROUND: Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  RESULTS: Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. CONCLUSIONS: Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.
+KW  - Pippi
+KW  - Nordwind
+KW  - Piraten
+JF  - Lorem
+JA  - lorem
+VL  - 9
+IS  - 3
+SP  - e0815
+CY  - United States
+PB  - Fun Factory
+SN  - 1932-6208
+M1  - 1008150341
+L2  - http://example.com
+UR  - http://example_url.com
+ER  -
+
+2.
+TY  - JOUR
+ID  - 12345
+T1  - The title of the reference
+A1  - Marxus, Karlus
+A1  - Lindgren, Astrid
+A2  - Glattauer, Daniel
+Y1  - 2006//
+N2  - BACKGROUND: Lorem dammed ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  RESULTS: Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. CONCLUSIONS: Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.
+KW  - Pippi Langstrumpf
+KW  - Nordwind
+KW  - Piraten
+JF  - Lorem
+JA  - lorem
+VL  - 6
+IS  - 3
+SP  - e0815341
+CY  - Germany
+PB  - Dark Factory
+SN  - 1732-4208
+M1  - 1228150341
+L2  - http://example2.com
+UR  - http://example_url.com
+ER  -

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -97,6 +97,63 @@ def test_load_example_full_ris():
     assert expected == entries
 
 
+
+def test_load_example_full_ris_with_whitespace():
+    
+    # Parse files without whitespace after ER tag. 
+    # Resolves https://github.com/MrTango/rispy/pull/25
+    
+    filepath = DATA_DIR / "example_full_without_whitespace.ris"
+    expected = [
+        {
+            "type_of_reference": "JOUR",
+            "id": "12345",
+            "primary_title": "Title of reference",
+            "first_authors": ["Marx, Karl", "Lindgren, Astrid"],
+            "secondary_authors": ["Glattauer, Daniel"],
+            "publication_year": "2014//",
+            "notes_abstract": "BACKGROUND: Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  RESULTS: Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. CONCLUSIONS: Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.",  # noqa: E501
+            "keywords": ["Pippi", "Nordwind", "Piraten"],
+            "alternate_title3": "Lorem",
+            "alternate_title2": "lorem",
+            "volume": "9",
+            "number": "3",
+            "start_page": "e0815",
+            "place_published": "United States",
+            "publisher": "Fun Factory",
+            "issn": "1932-6208",
+            "note": "1008150341",
+            "file_attachments2": "http://example.com",
+            "url": "http://example_url.com",
+        },
+        {
+            "type_of_reference": "JOUR",
+            "id": "12345",
+            "primary_title": "The title of the reference",
+            "first_authors": ["Marxus, Karlus", "Lindgren, Astrid"],
+            "secondary_authors": ["Glattauer, Daniel"],
+            "publication_year": "2006//",
+            "notes_abstract": "BACKGROUND: Lorem dammed ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  RESULTS: Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. CONCLUSIONS: Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.",  # noqa: E501
+            "keywords": ["Pippi Langstrumpf", "Nordwind", "Piraten"],
+            "alternate_title3": "Lorem",
+            "alternate_title2": "lorem",
+            "volume": "6",
+            "number": "3",
+            "start_page": "e0815341",
+            "place_published": "Germany",
+            "publisher": "Dark Factory",
+            "issn": "1732-4208",
+            "note": "1228150341",
+            "file_attachments2": "http://example2.com",
+            "url": "http://example_url.com",
+        },
+    ]
+
+    with open(filepath, "r") as f:
+        entries = rispy.loads(f.read())
+    assert expected == entries
+
+
 def test_load_single_unknown_tag_ris():
     filepath = DATA_DIR / "example_single_unknown_tag.ris"
     expected = {

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -97,8 +97,7 @@ def test_load_example_full_ris():
     assert expected == entries
 
 
-
-def test_load_example_full_ris_with_whitespace():
+def test_load_example_full_ris_without_whitespace():
     
     # Parse files without whitespace after ER tag. 
     # Resolves https://github.com/MrTango/rispy/pull/25

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -98,10 +98,10 @@ def test_load_example_full_ris():
 
 
 def test_load_example_full_ris_without_whitespace():
-    
-    # Parse files without whitespace after ER tag. 
+
+    # Parse files without whitespace after ER tag.
     # Resolves https://github.com/MrTango/rispy/pull/25
-    
+
     filepath = DATA_DIR / "example_full_without_whitespace.ris"
     expected = [
         {


### PR DESCRIPTION
This PR adds the option to have an end tag `ER  - ` without whitespace at the end (`ER  -`). Some major programs export RIS files without whitespace at the end (like Rayyan). 

Result: https://regex101.com/r/18TjBH/1. 

