### PR TITLE
Resolving Handling Extraneous/Malformed Data 

### DIFF
--- a/rispy/parser.py
+++ b/rispy/parser.py
@@ -199,7 +199,7 @@ def load(
         file (TextIO): File handle to read ris formatted data.
         mapping (Dict, optional): a tag mapping dictionary.
         implementation (RisImplementation): RIS implementation; base by default.
-        strict (bool): A boolean parameter that allows non-tag data between records to be silently ignored.
+        strict (bool): Boolean to allow non-tag data between records to be ignored.
 
     Returns:
         list: Returns list of RIS entries.
@@ -225,8 +225,8 @@ def loads(
         obj (str): A string version of an RIS file.
         mapping (Dict, optional): a tag mapping dictionary.
         implementation (RisImplementation): RIS implementation; base by default.
-        strict (bool): A boolean parameter that allows non-tag data between records to be silently ignored.
-        
+        strict (bool): Boolean to allow non-tag data between records to be ignored.
+
     Returns:
         list: Returns list of RIS entries.
     """

--- a/rispy/parser.py
+++ b/rispy/parser.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from typing import Dict, List, Optional, TextIO
 import re
 
-from config import LIST_TYPE_TAGS, TAG_KEY_MAPPING, WOK_TAG_KEY_MAPPING, WOK_LIST_TYPE_TAGS
+from .config import LIST_TYPE_TAGS, TAG_KEY_MAPPING, WOK_TAG_KEY_MAPPING, WOK_LIST_TYPE_TAGS
 
 
 __all__ = ["load", "loads"]

--- a/rispy/parser.py
+++ b/rispy/parser.py
@@ -24,7 +24,7 @@ class Base:
     IGNORE: List[str] = []
     PATTERN: str = None
 
-    def __init__(self, lines, mapping, strict):
+    def __init__(self, lines, mapping, strict=True):
         self.lines = lines
         self.pattern = re.compile(self.PATTERN)
         self._mapping = mapping

--- a/tests/data/example_extraneous_data.ris
+++ b/tests/data/example_extraneous_data.ris
@@ -1,0 +1,55 @@
+Record #1 of 2
+Provider: Provider
+Content: text/plain; charset="UTF-8"
+1.
+TY  - JOUR
+ID  - 12345
+T1  - Title of reference
+A1  - Marx, Karl
+A1  - Lindgren, Astrid
+A2  - Glattauer, Daniel
+Y1  - 2014//
+N2  - BACKGROUND: Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  RESULTS: Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. CONCLUSIONS: Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.
+KW  - Pippi
+KW  - Nordwind
+KW  - Piraten
+JF  - Lorem
+JA  - lorem
+VL  - 9
+IS  - 3
+SP  - e0815
+CY  - United States
+PB  - Fun Factory
+SN  - 1932-6208
+M1  - 1008150341
+L2  - http://example.com
+UR  - http://example_url.com
+ER  - 
+
+Record #2 of 2
+Provider: Provider
+Content: text/plain; charset="UTF-8"
+2.
+TY  - JOUR
+ID  - 12345
+T1  - The title of the reference
+A1  - Marxus, Karlus
+A1  - Lindgren, Astrid
+A2  - Glattauer, Daniel
+Y1  - 2006//
+N2  - BACKGROUND: Lorem dammed ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  RESULTS: Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. CONCLUSIONS: Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.
+KW  - Pippi Langstrumpf
+KW  - Nordwind
+KW  - Piraten
+JF  - Lorem
+JA  - lorem
+VL  - 6
+IS  - 3
+SP  - e0815341
+CY  - Germany
+PB  - Dark Factory
+SN  - 1732-4208
+M1  - 1228150341
+L2  - http://example2.com
+UR  - http://example_url.com
+ER  - 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -96,6 +96,56 @@ def test_load_example_full_ris():
         entries = rispy.loads(f.read())
     assert expected == entries
 
+def test_load_example_extraneous_data_ris():
+    filepath = DATA_DIR / "example_extraneous_data.ris"
+    expected = [
+        {
+            "type_of_reference": "JOUR",
+            "id": "12345",
+            "primary_title": "Title of reference",
+            "first_authors": ["Marx, Karl", "Lindgren, Astrid"],
+            "secondary_authors": ["Glattauer, Daniel"],
+            "publication_year": "2014//",
+            "notes_abstract": "BACKGROUND: Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  RESULTS: Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. CONCLUSIONS: Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.",  # noqa: E501
+            "keywords": ["Pippi", "Nordwind", "Piraten"],
+            "alternate_title3": "Lorem",
+            "alternate_title2": "lorem",
+            "volume": "9",
+            "number": "3",
+            "start_page": "e0815",
+            "place_published": "United States",
+            "publisher": "Fun Factory",
+            "issn": "1932-6208",
+            "note": "1008150341",
+            "file_attachments2": "http://example.com",
+            "url": "http://example_url.com",
+        },
+        {
+            "type_of_reference": "JOUR",
+            "id": "12345",
+            "primary_title": "The title of the reference",
+            "first_authors": ["Marxus, Karlus", "Lindgren, Astrid"],
+            "secondary_authors": ["Glattauer, Daniel"],
+            "publication_year": "2006//",
+            "notes_abstract": "BACKGROUND: Lorem dammed ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  RESULTS: Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. CONCLUSIONS: Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.",  # noqa: E501
+            "keywords": ["Pippi Langstrumpf", "Nordwind", "Piraten"],
+            "alternate_title3": "Lorem",
+            "alternate_title2": "lorem",
+            "volume": "6",
+            "number": "3",
+            "start_page": "e0815341",
+            "place_published": "Germany",
+            "publisher": "Dark Factory",
+            "issn": "1732-4208",
+            "note": "1228150341",
+            "file_attachments2": "http://example2.com",
+            "url": "http://example_url.com",
+        },
+    ]
+
+    with open(filepath, "r") as f:
+        entries = rispy.loads(f.read(), strict=False)
+    assert expected == entries
 
 def test_load_example_full_ris_without_whitespace():
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -96,6 +96,7 @@ def test_load_example_full_ris():
         entries = rispy.loads(f.read())
     assert expected == entries
 
+
 def test_load_example_extraneous_data_ris():
     filepath = DATA_DIR / "example_extraneous_data.ris"
     expected = [
@@ -146,6 +147,7 @@ def test_load_example_extraneous_data_ris():
     with open(filepath, "r") as f:
         entries = rispy.loads(f.read(), strict=False)
     assert expected == entries
+
 
 def test_load_example_full_ris_without_whitespace():
 


### PR DESCRIPTION
## Overview
As mentioned in issue #30 , 'Handling Extraneous/Malformed Data', we have a feature request where non-tag information between records need to be silently ignored. As mentioned, The .RIS export format from the Cochrane Library medical database inserts some meta information before every entry as shown below. This causes `rispy` to throw an `OSError` due to a non `TY` tag, since the first line is the meta information (ex. "Record #1 of 784"), as pointed out by @holub008 . Embase, Cochrane, and Ovid all produce malformed RIS data.

## Solution
As suggested by @shapiromatron , I added a `strict=True` parameter to `load` and `loads` which is a parameter that allows non-tag data between records to be silently ignored, with a default value of `True`. If set to `False`, then every non-tag line in the RIS file will be silently ignored. 

## Implementation
To minimize changes, the following changes were made:
1. Added `strict=True` parameter to `load` (which just passes it into `loads`)
2. Added `strict=True` parameter to `loads`
3. Added a `strict` parameter to the `Base` class constructor
4. Use the `strict` `Base` instance attribute in `parse_other` (which is called on non-tag lines) to silently ignore everything if `False`

## Files Changed
- `rispy/rispy/parser.py` - the main changes to resolve issue
- `rispy/tests/data/example_extraneous_data.ris` - a RIS file with extraneous data added similar to Cochrane for new test
- `rispy/tests/test_parser.py` - a new `test_load_example_extraneous_data_ris()` test case added

## Testing
Testing was done on a malformed RIS file on hand from Cochrane.

After implementation, I duplicated the `example_full.ris` file and added extraneous data similar to what Cochrane adds (see #30 for original example) and added a test in `tests/test_parser.py` called `test_load_example_extraneous_data_ris()` which is the same as `test_load_example_full_ris()` but using the `strict=False` parameter to `rispy.load`.

Note: If this approach is approved, then a more robust/different test case can be written for this new feature.

## Related People
@holub008 @shapiromatron 

Resolves #30 