### PR TITLE
biannual updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,12 @@ jobs:
 
   backend:
     name: lint + test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Python RIS files parser and reader
 .. image:: https://badge.fury.io/py/rispy.svg
    :target: https://badge.fury.io/py/rispy
 
-A Python 3.6+ reader/writer of RIS reference files.
+A Python 3.8+ reader/writer of RIS reference files.
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Writing:
    >>> filepath = 'export.ris'
    >>> with open(filepath, 'w') as bibliography_file:
    ...     rispy.dump(entries, bibliography_file)
-   
+
 
 Example RIS entry
 -----------------
@@ -252,7 +252,7 @@ Custom parsers can inherit ``RisParser`` (the default parser) or ``BaseParser``.
 Examples:
 
 .. code:: python
-   
+
    class WokParser(BaseParser):
        """Subclass of Base for reading Wok RIS files."""
 
@@ -324,15 +324,15 @@ Common developer commands are in the provided `Makefile`; if you don't have `mak
    # setup environment
    python -m venv venv
    source venv/bin/activate
-   pip install -e .[dev,test]
+   pip install -e ".[dev,test]"
 
    # check if code format changes are required
    make lint
-   
+
    # reformat code
    make format
 
    # run tests
-   make test 
+   make test
 
 Github Actions are currently enabled to run `lint` and `test` when submitting a pull-request.

--- a/rispy/writer.py
+++ b/rispy/writer.py
@@ -78,7 +78,6 @@ class BaseWriter(ABC):
         self.enforce_list_tags = enforce_list_tags
 
     def _get_reference_type(self, ref):
-
         if "type_of_reference" in ref.keys():
             # TODO add check
             return ref["type_of_reference"]
@@ -93,7 +92,6 @@ class BaseWriter(ABC):
         return self.PATTERN.format(tag=tag, value=value)
 
     def _format_reference(self, ref, count):
-
         lines = []
 
         header = self.set_header(count)
@@ -106,7 +104,6 @@ class BaseWriter(ABC):
             tags_to_skip.append("UK")
 
         for label, value in ref.items():
-
             # not available
             try:
                 tag = self._rev_mapping[label.lower()]
@@ -133,7 +130,6 @@ class BaseWriter(ABC):
         return lines
 
     def _format_all_references(self, references):
-
         for i, ref in enumerate(references):
             lines_ref = self._format_reference(ref, count=i + 1)
             for line in lines_ref:

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,13 +13,13 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.8
 packages = find:
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,5 +26,5 @@ packages = find:
 exclude = contrib; docs; tests*
 
 [options.extras_require]
-dev = black==21.5b1; flake8==3.7.9; check-manifest; wheel
+dev = black==23.3.0; flake8==6.0.0; check-manifest; wheel
 test = coverage; pytest

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -156,7 +156,6 @@ def test_load_example_extraneous_data_ris():
 
 
 def test_load_example_full_ris_without_whitespace():
-
     # Parse files without whitespace after ER tag.
     # Resolves https://github.com/MrTango/rispy/pull/25
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -23,7 +23,6 @@ def test_dump_and_load():
 
 
 def test_dumps_multiple_unknown_tags_ris(tmp_path):
-
     fp = tmp_path / "test_dump_unknown_tags.ris"
 
     results = [{"title": "my-title", "abstract": "my-abstract", "does_not_exists": "test"}]


### PR DESCRIPTION
It's been a while since we updated the tooling around rispy. This is a refresh and update to fix our pipelines:

* Update minimum python version to 3.8; max tested is now 3.11
* Update black to stable version; reformat code w/ latest version
* Update flake8 to recent version
* Fix github actions
