### PR TITLE
multiple URLs on import

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ Complete list of ListType tags
 
     >>> from rispy import LIST_TYPE_TAGS
     >>> print(LIST_TYPE_TAGS)
-    ['A1', 'A2', 'A3', 'A4', 'AU', 'KW', 'N1']
+    ['A1', 'A2', 'A3', 'A4', 'AU', 'KW', 'N1', 'UR']
 
 
 Complete default mapping
@@ -186,7 +186,7 @@ Complete default mapping
      'TT': 'translated_title',
      'TY': 'type_of_reference',
      'UK': 'unknown_tag',
-     'UR': 'url',
+     'UR': 'urls',
      'VL': 'volume',
      'Y1': 'publication_year',
      'Y2': 'access_date'}
@@ -225,7 +225,7 @@ The parser use a ``TAG_KEY_MAPPING``, which one can override by calling ``rispy.
     'publisher',
     'secondary_authors',
     'type_of_reference',
-    'url',
+    'urls',
     'volume']
 
 List tags can be customized in the same way, by passing a list to the ``list_tags`` parameter.

--- a/rispy/config.py
+++ b/rispy/config.py
@@ -8,6 +8,7 @@ LIST_TYPE_TAGS = [
     "AU",
     "KW",
     "N1",
+    "UR",
 ]
 
 TAG_KEY_MAPPING = {
@@ -70,7 +71,7 @@ TAG_KEY_MAPPING = {
     "TA": "translated_author",
     "TI": "title",
     "TT": "translated_title",
-    "UR": "url",
+    "UR": "urls",
     "VL": "volume",
     "Y1": "publication_year",
     "Y2": "access_date",

--- a/tests/data/example_urls.ris
+++ b/tests/data/example_urls.ris
@@ -1,0 +1,33 @@
+TY  - JOUR
+AU  - Shannon,Claude E.
+PY  - 1948/07//
+TI  - A Mathematical Theory of Communication
+JF  - Bell System Technical Journal
+SP  - 379
+EP  - 423
+VL  - 27
+UR  - http://example.com
+ER  -
+
+TY  - JOUR
+AU  - Shannon,Claude E.
+PY  - 1948/07//
+TI  - A Mathematical Theory of Communication
+JF  - Bell System Technical Journal
+SP  - 379
+EP  - 423
+VL  - 27
+UR  - http://example.com
+UR  - http://www.example.com
+ER  -
+
+TY  - JOUR
+AU  - Shannon,Claude E.
+PY  - 1948/07//
+TI  - A Mathematical Theory of Communication
+JF  - Bell System Technical Journal
+SP  - 379
+EP  - 423
+VL  - 27
+UR  - http://example.com; http://www.example.com
+ER  -

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -73,7 +73,7 @@ def test_load_example_full_ris():
             "issn": "1932-6208",
             "note": "1008150341",
             "file_attachments2": "http://example.com",
-            "url": "http://example_url.com",
+            "urls": ["http://example_url.com"],
         },
         {
             "type_of_reference": "JOUR",
@@ -94,7 +94,7 @@ def test_load_example_full_ris():
             "issn": "1732-4208",
             "note": "1228150341",
             "file_attachments2": "http://example2.com",
-            "url": "http://example_url.com",
+            "urls": ["http://example_url.com"],
         },
     ]
 
@@ -125,7 +125,7 @@ def test_load_example_extraneous_data_ris():
             "issn": "1932-6208",
             "note": "1008150341",
             "file_attachments2": "http://example.com",
-            "url": "http://example_url.com",
+            "urls": ["http://example_url.com"],
         },
         {
             "type_of_reference": "JOUR",
@@ -146,7 +146,7 @@ def test_load_example_extraneous_data_ris():
             "issn": "1732-4208",
             "note": "1228150341",
             "file_attachments2": "http://example2.com",
-            "url": "http://example_url.com",
+            "urls": ["http://example_url.com"],
         },
     ]
 
@@ -180,7 +180,7 @@ def test_load_example_full_ris_without_whitespace():
             "issn": "1932-6208",
             "note": "1008150341",
             "file_attachments2": "http://example.com",
-            "url": "http://example_url.com",
+            "urls": ["http://example_url.com"],
         },
         {
             "type_of_reference": "JOUR",
@@ -201,7 +201,7 @@ def test_load_example_full_ris_without_whitespace():
             "issn": "1732-4208",
             "note": "1228150341",
             "file_attachments2": "http://example2.com",
-            "url": "http://example_url.com",
+            "urls": ["http://example_url.com"],
         },
     ]
 
@@ -368,3 +368,14 @@ def test_list_tag_enforcement():
 
     entries = rispy.load(filepath, enforce_list_tags=False, list_tags=[])
     assert expected == entries[0]
+
+
+def test_url_tag():
+    filepath = DATA_DIR / "example_urls.ris"
+    with open(filepath, "r") as f:
+        entries = rispy.load(f)
+
+    assert len(entries) == 3
+    assert entries[0]["urls"] == ["http://example.com"]
+    assert entries[1]["urls"] == ["http://example.com", "http://www.example.com"]
+    assert entries[2]["urls"] == ["http://example.com", "http://www.example.com"]


### PR DESCRIPTION
Implements #47. 

This makes the RIS parser consistent with the [specification](https://github.com/MrTango/rispy/files/9707795/Direct.Export.RIS.pdf).

> Web/URL. There is no practical length limit to this field. URL addresses can be entered individually, one per tag, or multiple addresses can be entered on one line using a semi- colon as a separator.

Note that this is a breaking change. The "url" key is no longer used, and instead a "urls" key is used an results are saved as a list instead of a single string value, if exists.

