### PR TITLE
dump ris properly when tag is delimited but not a list tag

### DIFF
--- a/rispy/parser.py
+++ b/rispy/parser.py
@@ -71,7 +71,7 @@ class BaseParser(ABC):
         *,
         mapping: Optional[Dict] = None,
         list_tags: Optional[List[str]] = None,
-        delimiter_mapping: Optional[Dict] = None,
+        delimiter_tags_mapping: Optional[Dict] = None,
         ignore: Optional[List[str]] = None,
         skip_missing_tags: bool = False,
         skip_unknown_tags: bool = False,
@@ -82,7 +82,7 @@ class BaseParser(ABC):
         Args:
             mapping (dict, optional): Map tags to tag names.
             list_tags (list, optional): List of list-type tags.
-            delimiter_mapping (dict, optional): Map of delimiters to tags.
+            delimiter_tags_mapping (dict, optional): Map of delimiters to tags.
             ignore (list, optional): List of tags to ignore.
             skip_missing_tags (bool, optional): Bool to skip lines that don't have
                                                 valid tags, regardless of whether
@@ -111,7 +111,9 @@ class BaseParser(ABC):
         self.mapping = mapping if mapping is not None else self.DEFAULT_MAPPING
         self.list_tags = list_tags if list_tags is not None else self.DEFAULT_LIST_TAGS
         self.delimiter_map = (
-            delimiter_mapping if delimiter_mapping is not None else self.DEFAULT_DELIMITER_MAPPING
+            delimiter_tags_mapping
+            if delimiter_tags_mapping is not None
+            else self.DEFAULT_DELIMITER_MAPPING
         )
         self.ignore = ignore if ignore is not None else self.DEFAULT_IGNORE
         self.skip_missing_tags = skip_missing_tags

--- a/rispy/parser.py
+++ b/rispy/parser.py
@@ -59,6 +59,7 @@ class BaseParser(ABC):
 
     START_TAG: str
     END_TAG: str = "ER"
+    UNKNOWN_TAG: str = "UK"
     PATTERN: str
     DEFAULT_IGNORE: ClassVar[List[str]] = []
     DEFAULT_MAPPING: Dict
@@ -240,7 +241,7 @@ class BaseParser(ABC):
             self._add_single_value(name, new_value, is_multi=all_line)
 
     def _add_unknown_tag(self, tag, line):
-        name = self.mapping["UK"]
+        name = self.mapping[self.UNKNOWN_TAG]
         value = self.get_content(line)
         # check if unknown_tag dict exists
         if name not in self.current:

--- a/rispy/writer.py
+++ b/rispy/writer.py
@@ -54,7 +54,7 @@ class BaseWriter(ABC):
         *,
         mapping: Optional[Dict] = None,
         list_tags: Optional[List[str]] = None,
-        delimiter_mapping: Optional[Dict] = None,
+        delimiter_tags_mapping: Optional[Dict] = None,
         ignore: Optional[List[str]] = None,
         skip_unknown_tags: bool = False,
         enforce_list_tags: bool = True,
@@ -64,7 +64,7 @@ class BaseWriter(ABC):
         Args:
             mapping (dict, optional): Map tags to tag names.
             list_tags (list, optional): List of list-type tags.
-            delimiter_mapping (dict, optional): Map of delimiters to tags.
+            delimiter_tags_mapping (dict, optional): Map of delimiters to tags.
             ignore (list, optional): List of tags to ignore.
             skip_unknown_tags (bool, optional): Bool for whether to write unknown
                                                 tags to the file. Defaults to
@@ -77,7 +77,9 @@ class BaseWriter(ABC):
         self.mapping = mapping if mapping is not None else self.DEFAULT_MAPPING
         self.list_tags = list_tags if list_tags is not None else self.DEFAULT_LIST_TAGS
         self.delimiter_map = (
-            delimiter_mapping if delimiter_mapping is not None else self.DEFAULT_DELIMITER_MAPPING
+            delimiter_tags_mapping
+            if delimiter_tags_mapping is not None
+            else self.DEFAULT_DELIMITER_MAPPING
         )
         self.ignore = ignore if ignore is not None else self.DEFAULT_IGNORE
         self._rev_mapping = invert_dictionary(self.mapping)

--- a/rispy/writer.py
+++ b/rispy/writer.py
@@ -4,7 +4,7 @@ import warnings
 from abc import ABC
 from typing import ClassVar, Dict, List, Optional, TextIO, Type
 
-from .config import LIST_TYPE_TAGS, TAG_KEY_MAPPING
+from .config import DELIMITED_TAG_MAPPING, LIST_TYPE_TAGS, TAG_KEY_MAPPING
 from .utils import invert_dictionary
 
 __all__ = ["dump", "dumps", "BaseWriter", "RisWriter"]
@@ -39,11 +39,14 @@ class BaseWriter(ABC):
 
     START_TAG: str
     END_TAG: str = "ER"
+    UNKNOWN_TAG: str = "UK"
     PATTERN: str
     DEFAULT_IGNORE: ClassVar[List[str]] = []
     DEFAULT_MAPPING: Dict
     DEFAULT_LIST_TAGS: List[str]
+    DEFAULT_DELIMITER_MAPPING: Dict
     DEFAULT_REFERENCE_TYPE: str = "JOUR"
+    REFERENCE_TYPE_KEY: str = "type_of_reference"
     SEPARATOR: Optional[str] = "\n"
 
     def __init__(
@@ -51,6 +54,7 @@ class BaseWriter(ABC):
         *,
         mapping: Optional[Dict] = None,
         list_tags: Optional[List[str]] = None,
+        delimiter_mapping: Optional[Dict] = None,
         ignore: Optional[List[str]] = None,
         skip_unknown_tags: bool = False,
         enforce_list_tags: bool = True,
@@ -60,6 +64,7 @@ class BaseWriter(ABC):
         Args:
             mapping (dict, optional): Map tags to tag names.
             list_tags (list, optional): List of list-type tags.
+            delimiter_mapping (dict, optional): Map of delimiters to tags.
             ignore (list, optional): List of tags to ignore.
             skip_unknown_tags (bool, optional): Bool for whether to write unknown
                                                 tags to the file. Defaults to
@@ -71,15 +76,18 @@ class BaseWriter(ABC):
         """
         self.mapping = mapping if mapping is not None else self.DEFAULT_MAPPING
         self.list_tags = list_tags if list_tags is not None else self.DEFAULT_LIST_TAGS
+        self.delimiter_map = (
+            delimiter_mapping if delimiter_mapping is not None else self.DEFAULT_DELIMITER_MAPPING
+        )
         self.ignore = ignore if ignore is not None else self.DEFAULT_IGNORE
         self._rev_mapping = invert_dictionary(self.mapping)
         self.skip_unknown_tags = skip_unknown_tags
         self.enforce_list_tags = enforce_list_tags
 
     def _get_reference_type(self, ref):
-        if "type_of_reference" in ref.keys():
+        if self.REFERENCE_TYPE_KEY in ref:
             # TODO add check
-            return ref["type_of_reference"]
+            return ref[self.REFERENCE_TYPE_KEY]
 
         if self.DEFAULT_REFERENCE_TYPE is not None:
             return self.DEFAULT_REFERENCE_TYPE
@@ -100,7 +108,7 @@ class BaseWriter(ABC):
 
         tags_to_skip = [self.START_TAG, *self.ignore]
         if self.skip_unknown_tags:
-            tags_to_skip.append("UK")
+            tags_to_skip.append(self.UNKNOWN_TAG)
 
         for label, value in ref.items():
             # not available
@@ -120,16 +128,21 @@ class BaseWriter(ABC):
                     lines.append(self._format_line(tag, val_i))
 
             # unknown tag(s), which are lists held in a defaultdict
-            elif tag == "UK":
+            elif tag == self.UNKNOWN_TAG:
                 for unknown_tag in value.keys():
                     for val_i in value[unknown_tag]:
                         lines.append(self._format_line(unknown_tag, val_i))
+
+            # write delimited tags
+            elif tag in self.delimiter_map:
+                combined_val = self.delimiter_map[tag].join(value)
+                lines.append(self._format_line(tag, combined_val))
 
             # all non-list tags
             else:
                 lines.append(self._format_line(tag, value))
 
-        lines.append(self._format_line("ER"))
+        lines.append(self._format_line(self.END_TAG))
 
         if self.SEPARATOR is not None:
             lines.append(self.SEPARATOR.replace("\n", "", 1))
@@ -159,6 +172,7 @@ class RisWriter(BaseWriter):
     PATTERN = "{tag}  - {value}"
     DEFAULT_MAPPING = TAG_KEY_MAPPING
     DEFAULT_LIST_TAGS = LIST_TYPE_TAGS
+    DEFAULT_DELIMITER_MAPPING = DELIMITED_TAG_MAPPING
 
     def set_header(self, count):
         return f"{count}."

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -197,6 +197,7 @@ def test_delimited_dump():
     entries = [
         {
             "type_of_reference": "JOUR",
+            "authors": ["Shannon, Claude E.", "Doe, John"],
             "year": "1948/07//",
             "title": "A Mathematical Theory of Communication",
             "start_page": "379",
@@ -204,9 +205,11 @@ def test_delimited_dump():
         }
     ]
 
-    text_output = rispy.dumps(entries, list_tags=[])
+    text_output = rispy.dumps(entries, list_tags=["AU"], delimiter_mapping={"UR": ","})
 
     # check output is as expected
     lines = text_output.splitlines()
-    assert lines[5] == "UR  - https://example.com;https://example2.com"
-    assert len(lines) == 7
+    assert lines[2] == "AU  - Shannon, Claude E."
+    assert lines[3] == "AU  - Doe, John"
+    assert lines[7] == "UR  - https://example.com,https://example2.com"
+    assert len(lines) == 9

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -193,6 +193,27 @@ def test_write_multiple_unknown_tag_diff_type():
     assert len(lines) == 9
 
 
+def test_default_dump():
+    entries = [
+        {
+            "type_of_reference": "JOUR",
+            "authors": ["Shannon, Claude E.", "Doe, John"],
+            "year": "1948/07//",
+            "title": "A Mathematical Theory of Communication",
+            "start_page": "379",
+            "urls": ["https://example.com", "https://example2.com"],
+        }
+    ]
+
+    text_output = rispy.dumps(entries)
+    lines = text_output.splitlines()
+    assert lines[2] == "AU  - Shannon, Claude E."
+    assert lines[3] == "AU  - Doe, John"
+    assert lines[7] == "UR  - https://example.com"
+    assert lines[8] == "UR  - https://example2.com"
+    assert len(lines) == 10
+
+
 def test_delimited_dump():
     entries = [
         {
@@ -205,6 +226,7 @@ def test_delimited_dump():
         }
     ]
 
+    # remove URLs from list_tags and give it a custom delimiter
     text_output = rispy.dumps(entries, list_tags=["AU"], delimiter_mapping={"UR": ","})
 
     # check output is as expected

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -191,3 +191,22 @@ def test_write_multiple_unknown_tag_diff_type():
     assert lines[6] == "JP  - CRISPR"
     assert lines[7] == "ED  - Swinburne, Ricardo"
     assert len(lines) == 9
+
+
+def test_delimited_dump():
+    entries = [
+        {
+            "type_of_reference": "JOUR",
+            "year": "1948/07//",
+            "title": "A Mathematical Theory of Communication",
+            "start_page": "379",
+            "urls": ["https://example.com", "https://example2.com"],
+        }
+    ]
+
+    text_output = rispy.dumps(entries, list_tags=[])
+
+    # check output is as expected
+    lines = text_output.splitlines()
+    assert lines[5] == "UR  - https://example.com;https://example2.com"
+    assert len(lines) == 7

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -227,7 +227,7 @@ def test_delimited_dump():
     ]
 
     # remove URLs from list_tags and give it a custom delimiter
-    text_output = rispy.dumps(entries, list_tags=["AU"], delimiter_mapping={"UR": ","})
+    text_output = rispy.dumps(entries, list_tags=["AU"], delimiter_tags_mapping={"UR": ","})
 
     # check output is as expected
     lines = text_output.splitlines()


### PR DESCRIPTION
If a tag is marked as delimited but not a list tag, the parser will read it in as a list, but will only a single tag (i.e. if the tag is repeated it will be skipped). This was added in #52 

If the writer encounters a list tag, whether it is delimited or not, it will write multiple keys. This PR fixes the case where a tag is delimited but not a list tag. Logic was added to re-combine the values of the list with the provided delimiter. 

This PR also replaces some hard-coded tags with class variables. 