### PR TITLE
Handling tags with empty values

### DIFF
--- a/rispy/parser.py
+++ b/rispy/parser.py
@@ -319,7 +319,7 @@ class RisParser(BaseParser):
     """Subclass of Base for reading base RIS files."""
 
     START_TAG = "TY"
-    PATTERN = r"^[A-Z][A-Z0-9]  - |^ER  -\s*$"
+    PATTERN = r"^[A-Z][A-Z0-9]  - ?|^ER  -\s*$"
     DEFAULT_MAPPING = TAG_KEY_MAPPING
     DEFAULT_LIST_TAGS = LIST_TYPE_TAGS
     DEFAULT_DELIMITER_MAPPING = DELIMITED_TAG_MAPPING

--- a/tests/data/example_empty_tag.ris
+++ b/tests/data/example_empty_tag.ris
@@ -1,0 +1,19 @@
+TY  - JOUR
+ID  - 2006713348
+T1  - Outcome Measures After Shoulder Stabilization in the Athletic Population: A Systematic Review of Clinical and Patient-Reported Metrics
+A1  - Fanning E.
+Y1  - 2020//
+N2  - Background: Athletic endeavor can require the "athletic shoulder" to tolerate significant load through supraphysiological range and often under considerable repetition.
+Outcome measures are valuable when determining an athlete's safe return to sport...
+KW  - *athlete
+KW  - biomechanics
+KW  - bone remodeling
+JF  - Orthopaedic Journal of Sports Medicine
+JA  - Orthop. J. Sports Med.
+VL  - 8
+IS  - 9
+SP  -
+PB  - SAGE Publications Ltd (E-mail: info@sagepub.co.uk)
+SN  - 2325-9671 (electronic)
+DO  - http://dx.doi.org/10.1177/2325967120950040
+ER  -

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -378,3 +378,12 @@ def test_url_tag():
     assert entries[1]["urls"] == ["http://example.com", "http://www.example.com"]
     assert entries[2]["urls"] == ["http://example.com", "http://www.example.com"]
     assert entries[3]["urls"] == ["http://example.com", "http://www.example.com"]
+
+def test_empty_tag():
+    filepath = DATA_DIR / "example_empty_tag.ris"
+    with open(filepath) as f:
+        entries = rispy.load(f)
+
+    assert len(entries) == 1
+    assert entries[0]['number'] == '9'
+    assert entries[0]['start_page'] == ''

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -379,11 +379,12 @@ def test_url_tag():
     assert entries[2]["urls"] == ["http://example.com", "http://www.example.com"]
     assert entries[3]["urls"] == ["http://example.com", "http://www.example.com"]
 
+
 def test_empty_tag():
     filepath = DATA_DIR / "example_empty_tag.ris"
     with open(filepath) as f:
         entries = rispy.load(f)
 
     assert len(entries) == 1
-    assert entries[0]['number'] == '9'
-    assert entries[0]['start_page'] == ''
+    assert entries[0]["number"] == "9"
+    assert entries[0]["start_page"] == ""


### PR DESCRIPTION
Resolves: #62 

Implementation: By making the space after a tag optional in the line `PATTERN`, content of `''` will be extracted for the line, rather than failing to match the line pattern and concatenating the entire line to the current tag's content.

Testing: In addition to the test cases, I ran this change against my company's internal test suite for file import and saw no regression. Linter passes.