### PR TITLE
Revert strip UTF-8 BOM strip

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A file path can also be used to read RIS files. If an encoding is not specified 
 >>> from pathlib import Path
 >>> import rispy
 >>> p = Path('tests', 'data', 'example_utf_chars.ris')
->>> entries = rispy.load(p, encoding='utf-8')
+>>> entries = rispy.load(p, encoding='utf-8-sig')
 >>> for entry in entries:
 ...     print(entry['authors'][0])
 Dobrokhotova, Yu E.

--- a/rispy/parser.py
+++ b/rispy/parser.py
@@ -52,8 +52,6 @@ class BaseParser(ABC):
                  first two characters.
         is_tag: Determines whether a line has a tag, returning a bool. Uses
                 regex in `PATTERN` by default.
-        clean_start: Clean the first line of the document. By default,
-                    it removes UTF-BOM characters.
         clean_text: Clean each line before it's parsed.
 
     """
@@ -142,9 +140,6 @@ class BaseParser(ABC):
 
         for line in lines:
             self.line_number += 1
-
-            if self.line_number == 0:
-                line = self.clean_start(line)
 
             line = self.clean_text(line)
 
@@ -269,12 +264,6 @@ class BaseParser(ABC):
 
     def clean_text(self, text: str) -> str:
         """CLean each line."""
-        return text
-
-    def clean_start(self, text: str) -> str:
-        """Clean the first line."""
-        # remove BOM if present
-        text = text.lstrip("\ufeff")
         return text
 
     def get_tag(self, line: str) -> str:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -263,7 +263,7 @@ def test_strip_bom():
     filepath = DATA_DIR / "example_bom.ris"
 
     # we properly decode the content of this file as UTF-8, but leave the BOM
-    with open(filepath, encoding="utf-8") as f:
+    with open(filepath, encoding="utf-8-sig") as f:
         entries = rispy.load(f)
 
     assert expected == entries[0]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -341,16 +341,15 @@ def test_type_conversion():
 
 
 def test_encodings():
-    fn = DATA_DIR / "example_utf_chars.ris"
-    p = Path(fn)
+    p = DATA_DIR / "example_utf_chars.ris"
 
-    with open(fn, encoding="utf-8") as file:
+    with open(p, encoding="utf-8-sig") as file:
         expected = rispy.load(file)
 
     with pytest.raises(UnicodeDecodeError):
         rispy.load(p, encoding="cp1252")
 
-    entries = rispy.load(p, encoding="utf-8")
+    entries = rispy.load(p, encoding="utf-8-sig")
 
     assert entries == expected
 


### PR DESCRIPTION
In this PR, I propose to revert @holub008's fix of issue #13 in PR #23. The work might no longer be needed and also negatively impacts rispy's performance. 

The original issue reports that Endnote uses UTF-8-BOM for encoding. I can't reproduce that anymore, so this might no longer be true. Rispy has nowadays very good support for handling encoding, so I propose to remove support. 

