### PR TITLE
Improve performance of rispy's parser and refactor parser

### DIFF
--- a/rispy/parser.py
+++ b/rispy/parser.py
@@ -52,8 +52,6 @@ class BaseParser(ABC):
                  first two characters.
         is_tag: Determines whether a line has a tag, returning a bool. Uses
                 regex in `PATTERN` by default.
-        clean_start: Clean the first line of the document. By default,
-                    it removes UTF-BOM characters.
         clean_text: Clean each line before it's parsed.
 
     """
@@ -142,9 +140,6 @@ class BaseParser(ABC):
 
         for line in lines:
             self.line_number += 1
-
-            if self.line_number == 0:
-                line = self.clean_start(line)
 
             line = self.clean_text(line)
 
@@ -269,12 +264,6 @@ class BaseParser(ABC):
 
     def clean_text(self, text: str) -> str:
         """CLean each line."""
-        return text
-
-    def clean_start(self, text: str) -> str:
-        """Clean the first line."""
-        # remove BOM if present
-        text = text.lstrip("\ufeff")
         return text
 
     def get_tag(self, line: str) -> str:

--- a/tests/data/example_empty_tag.ris
+++ b/tests/data/example_empty_tag.ris
@@ -1,0 +1,19 @@
+TY  - JOUR
+ID  - 2006713348
+T1  - Outcome Measures After Shoulder Stabilization in the Athletic Population: A Systematic Review of Clinical and Patient-Reported Metrics
+A1  - Fanning E.
+Y1  - 2020//
+N2  - Background: Athletic endeavor can require the "athletic shoulder" to tolerate significant load through supraphysiological range and often under considerable repetition.
+Outcome measures are valuable when determining an athlete's safe return to sport...
+KW  - *athlete
+KW  - biomechanics
+KW  - bone remodeling
+JF  - Orthopaedic Journal of Sports Medicine
+JA  - Orthop. J. Sports Med.
+VL  - 8
+IS  - 9
+SP  -
+PB  - SAGE Publications Ltd (E-mail: info@sagepub.co.uk)
+SN  - 2325-9671 (electronic)
+DO  - http://dx.doi.org/10.1177/2325967120950040
+ER  -

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -31,6 +31,23 @@ def test_load_example_basic_ris():
     assert expected == entries[0]
 
 
+def test_loads():
+
+    ristext = (DATA_DIR / "example_basic.ris").read_text()
+    expected = {
+        "type_of_reference": "JOUR",
+        "authors": ["Shannon,Claude E."],
+        "year": "1948/07//",
+        "title": "A Mathematical Theory of Communication",
+        "alternate_title3": "Bell System Technical Journal",
+        "start_page": "379",
+        "end_page": "423",
+        "volume": "27",
+    }
+
+    assert expected == rispy.loads(ristext)[0]
+
+
 def test_load_multiline_ris():
     filepath = DATA_DIR / "multiline.ris"
     expected = {
@@ -151,7 +168,7 @@ def test_load_example_extraneous_data_ris():
     ]
 
     with open(filepath) as f:
-        entries = rispy.load(f, skip_missing_tags=True)
+        entries = rispy.load(f)
     assert expected == entries
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -263,7 +263,7 @@ def test_strip_bom():
     filepath = DATA_DIR / "example_bom.ris"
 
     # we properly decode the content of this file as UTF-8, but leave the BOM
-    with open(filepath, encoding="utf-8") as f:
+    with open(filepath, encoding="utf-8-sig") as f:
         entries = rispy.load(f)
 
     assert expected == entries[0]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -395,3 +395,13 @@ def test_url_tag():
     assert entries[1]["urls"] == ["http://example.com", "http://www.example.com"]
     assert entries[2]["urls"] == ["http://example.com", "http://www.example.com"]
     assert entries[3]["urls"] == ["http://example.com", "http://www.example.com"]
+
+
+def test_empty_tag():
+    filepath = DATA_DIR / "example_empty_tag.ris"
+    with open(filepath) as f:
+        entries = rispy.load(f)
+
+    assert len(entries) == 1
+    assert entries[0]["number"] == "9"
+    assert entries[0]["start_page"] == ""


### PR DESCRIPTION
This PR proposes to refactor and improve performance. Although breaking changes are not necessary, I would recommend changing parts of the API as well. Happy to hear your thoughts

## Performance 

I used PR #65 to test the performance of rispy on my machine.

Current main branch: **Time: 50.5917 s**
This PR: **Time: 20.3249 s**

According to this benchmark, this implementation is 2.5x faster. This seems to hold for both small and larger datasets. 

## No more regexp

This PR removes the need for regular expressions. Everything between the start and end tags is a tag with a specific format. So, you don't need to apply a regular expression to each line. This saves a lot of time and potential mistakes. 

I left the current regexp class attribute definition, but I would suggest to remove it.

## Issues resolved

This PR also resolves:

- #62 and #63 by @holub008. No extra changes were needed to make this work on the test defined by @holub008 in PR #63. 
- #61 by @holub008. Resolved by design. 

## API changes

We can simplify, improve, and refactor a bit more. I'll leave that for a moment until the community has looked over this proposal. 

## Other

I added PR #64's changes to this PR for convenience. They can/will be changed after a decision has been made on PR #64. 

