### PR TITLE
Increase performance of parser

### DIFF
--- a/rispy/config.py
+++ b/rispy/config.py
@@ -1,6 +1,5 @@
 """Define default mappings."""
-
-LIST_TYPE_TAGS = [
+LIST_TYPE_TAGS = {
     "A1",
     "A2",
     "A3",
@@ -9,7 +8,7 @@ LIST_TYPE_TAGS = [
     "KW",
     "N1",
     "UR",
-]
+}
 
 DELIMITED_TAG_MAPPING = {
     "UR": ";",
@@ -141,7 +140,7 @@ TYPE_OF_REFERENCE_MAPPING = {
     "VIDEO": "Video recording",
 }
 
-WOK_LIST_TYPE_TAGS = [
+WOK_LIST_TYPE_TAGS = {
     "RI",
     "CR",
     "AF",
@@ -150,7 +149,7 @@ WOK_LIST_TYPE_TAGS = [
     "AU",
     "CA",
     "GP",
-]
+}
 
 WOK_TAG_KEY_MAPPING = {
     "FN": "file_name",

--- a/rispy/config.py
+++ b/rispy/config.py
@@ -1,4 +1,5 @@
 """Define default mappings."""
+
 LIST_TYPE_TAGS = {
     "A1",
     "A2",

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -67,7 +67,7 @@ def test_dumps_multiple_unknown_tags_ris(tmp_path):
 def test_custom_list_tags():
     filepath = DATA_DIR / "example_custom_list_tags.ris"
     list_tags = deepcopy(rispy.LIST_TYPE_TAGS)
-    list_tags.append("SN")
+    list_tags.add("SN")
 
     expected = {
         "type_of_reference": "JOUR",


### PR DESCRIPTION
As we approach the v1 release, I believe it's time for this API change. This will result in a savings of around 15-20% on a large dataset. 

```
------------------------------------------------------------------------------------------------- benchmark: 2 tests -------------------------------------------------------------------------------------------------
Name (time in ms)                                Min                   Max                  Mean             StdDev                Median                IQR            Outliers     OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_real_data (0004_use_set)     800.9379 (1.0)        883.0898 (1.0)        838.6729 (1.0)      29.1617 (1.0)        836.2794 (1.0)      35.6849 (1.0)           4;0  1.1924 (1.0)          10           5
test_benchmark_real_data (0005_no_set_)     935.0793 (1.17)     1,097.2022 (1.24)     1,013.3880 (1.21)     59.4632 (2.04)     1,003.6009 (1.20)     88.8859 (2.49)          4;0  0.9868 (0.83)         10           5
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```