### PR TITLE
Ignore benchmark related files and internal benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ venv
 
 # created from tests
 export.ris
+
+# extra benchmark data only for internal use (because of copyright)
+benchmark_data
+tests/test_benchmark_internal.py
+benchmark_*.svg


### PR DESCRIPTION
Usually, I'm not a big fan of solutions like this, but given the importance of performance, I think this pragmatic solution can be acceptable. I utilize large, real-world datasets to benchmark the parser's performance and frequently need to switch between branches.

Btw, I'm making nice progress on the PubMed parsing PR, but there are still some open challenges. Performance is one of them. 